### PR TITLE
Fix Cartographer Trade Image

### DIFF
--- a/Project/libraries/Versions/Snapshot/25w07a.md
+++ b/Project/libraries/Versions/Snapshot/25w07a.md
@@ -48,7 +48,7 @@ cats: ['1.21','1.21.5']
 
 ![25w07a_cartographer_trades.png](https://img.picgo.net/2025/02/14/image27c7c5854ab5576c.png)
 
-[原图](https://minecraftnetassets.z13.web.core.windows.net/minecraft-net-assets-container/25w07a_wandering_trader_trades.png)
+[原图](https://www.minecraft.net/content/dam/minecraftnet/games/minecraft/screenshots/25w07a_cartographer_trades.jpg)
 
 #### 流浪商人交易项调整
 


### PR DESCRIPTION
制图师交易的原图链接错了，现在更正为官网上的正确图片