### PR TITLE
因为Minecraftwiki的图片源时常403，所以换成了官网的

### DIFF
--- a/Project/libraries/News/MinecraftLive2025.md
+++ b/Project/libraries/News/MinecraftLive2025.md
@@ -1,6 +1,6 @@
 # Minecraft LIVE 即将回归
 
-![一些生物走在一起，背后是晴朗的天空](https://zh.minecraft.wiki/images/thumb/MC_Live_Announcement_Key_Art.jpeg/1280px-MC_Live_Announcement_Key_Art.jpeg?da3e0)
+![一些生物走在一起，背后是晴朗的天空](https://www.minecraft.net/content/dam/minecraftnet/games/minecraft/marketplace/MCL_Announce_Key_Art_DotNet_Blog_Editorial_1170x500.jpg)
 Minecraft LIVE 是了解 Minecraft 世界动态的绝佳节目！
 
 ### Mojang 的下一场直播将于 3 月 22 日星期六，美国东部时间下午 1 点进行


### PR DESCRIPTION
![PixPin_2025-03-19_23-07-32](https://github.com/user-attachments/assets/74b65773-5a32-4eac-bed3-1b1ec87b28f4)
